### PR TITLE
Update Instana Agent GCP app

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ ClusterRole, ClusterRoleBinding and ServiceAccount are defined in schema.yaml
 ```
 #!/usr/bin/env bash
 export REGISTRY=gcr.io/instana-public
+export DEPLOYER_TAG=1.3
 export TAG=latest
 export APP_NAME=instana-agent
 
@@ -78,9 +79,9 @@ sudo docker build \
 --build-arg REGISTRY=$REGISTRY \
 --build-arg APP_NAME=$APP_NAME \
 --build-arg TAG=$TAG \
---tag $REGISTRY/$APP_NAME/deployer .
+--tag $REGISTRY/$APP_NAME/deployer:$DEPLOYER_TAG .
 
-sudo docker push $REGISTRY/$APP_NAME/deployer
+sudo docker push $REGISTRY/$APP_NAME/deployer:$DEPLOYER_TAG
 
 mpdev /scripts/install \
 --deployer=$REGISTRY/$APP_NAME/deployer \

--- a/chart/instana-agent/Chart.yaml
+++ b/chart/instana-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: instana-agent
 version: 1.0.19
-appVersion: 1.2
+appVersion: 1.3
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/
 icon: http://instana-management-assets.s3-website-eu-west-1.amazonaws.com/stan_icon_front_black_big.png

--- a/chart/instana-agent/Chart.yaml
+++ b/chart/instana-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.18
+version: 1.0.19
 appVersion: 1.2
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/chart/instana-agent/templates/daemonset.yaml
+++ b/chart/instana-agent/templates/daemonset.yaml
@@ -116,6 +116,7 @@ spec:
             {{- end }}
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /status
               port: 42699
             initialDelaySeconds: 75
@@ -147,6 +148,7 @@ spec:
               memory: 64Mi
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /status
               port: 42699
             initialDelaySeconds: 75

--- a/chart/instana-agent/templates/daemonset.yaml
+++ b/chart/instana-agent/templates/daemonset.yaml
@@ -105,6 +105,8 @@ spec:
               mountPath: /sys
             - name: var-log
               mountPath: /var/log
+            - name: var-lib
+              mountPath: /var/lib/containers/storage
             - name: machine-id
               mountPath: /etc/machine-id
             - name: configuration
@@ -175,6 +177,9 @@ spec:
         - name: var-log
           hostPath:
             path: /var/log
+        - name: var-lib
+          hostPath:
+            path: /var/lib/containers/storage
         - name: machine-id
           hostPath:
             path: /etc/machine-id


### PR DESCRIPTION
This changeset includes:
- Mount `/var/lib/containers/storage` in the `DaemonSet` for CRI-O support
- Specify host in the `livenessProbe` for both the `instana-agent` and `leader-elector` containers
- Bumping Chart version from 1.0.18 to 1.0.19
- Bumping app version from 1.2 to 1.3