### PR TITLE
Update with the latest from the Instana Agent helm chart 1.0.23

### DIFF
--- a/chart/instana-agent/Chart.yaml
+++ b/chart/instana-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.21
-appVersion: 1.6
+version: 1.0.23
+appVersion: 1.7
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/
 icon: http://instana-management-assets.s3-website-eu-west-1.amazonaws.com/stan_icon_front_black_big.png

--- a/chart/instana-agent/templates/daemonset.yaml
+++ b/chart/instana-agent/templates/daemonset.yaml
@@ -96,6 +96,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            {{- range $key, $value := .Values.agent.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -124,8 +128,8 @@ spec:
             httpGet:
               path: /status
               port: 42699
-            initialDelaySeconds: 75
-            periodSeconds: 5
+            initialDelaySeconds: 300
+            timeoutSeconds: 3
           resources:
             requests:
               memory: "{{ default 512 .Values.agent.pod.requests.memory }}Mi"
@@ -155,8 +159,8 @@ spec:
             httpGet:
               path: /status
               port: 42699
-            initialDelaySeconds: 75
-            periodSeconds: 5
+            initialDelaySeconds: 300
+            timeoutSeconds: 3
           ports:
             - containerPort: {{ .Values.agent.leaderElectorPort }}
       {{- if .Values.agent.pod.tolerations }}

--- a/chart/instana-agent/values.yaml
+++ b/chart/instana-agent/values.yaml
@@ -62,6 +62,12 @@ agent:
   # agent.proxyUseDNS sets the INSTANA_AGENT_PROXY_USE_DNS environment variable.
   # proxyUseDNS: null
 
+  # use this to set additional environment variables for the instana agent
+  # for example:
+  # env:
+  #   INSTANA_AGENT_TAGS: dev
+  env: {}
+
   configuration_yaml: |
     # Place agent configuration here
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export REGISTRY=gcr.io/instana-public
-export DEPLOYER_TAG=1.6
+export DEPLOYER_TAG=1.7
 export TAG=latest
 export APP_NAME=instana-agent
 


### PR DESCRIPTION
- Increase liveness probe initial time to 5 minutes, period to 10 seconds, and timeout to 3 seconds
- Allow specifying arbitrary environment variables for agent in values
- Bump chart version to 1.0.23 to match helm chart